### PR TITLE
Immutable Trees

### DIFF
--- a/discretesampling/domain/decision_tree/tree.py
+++ b/discretesampling/domain/decision_tree/tree.py
@@ -10,7 +10,7 @@ class Tree(types.DiscreteVariable):
         self.X_train.flags.writeable = False
         self.y_train = y_train
         self.y_train.flags.writeable = False
-        self.tree = tuple(tree)
+        self.tree = tuple(tuple(x) for x in tree)
         self.leafs = tuple(leafs)
 
 


### PR DESCRIPTION
Making trees immutable might help to avoid some headaches elsewhere; prune, grow, change and swap should return new trees rather than changing the current tree.

Not sure if this is sensible to do or not. It might be sensible to make DiscreteVariables in general immutable for the same reason. It also makes it possible to add a `__hash__` function to a class.