### PR TITLE
Add progress bars for MCMC and SMC

### DIFF
--- a/discretesampling/base/algorithms/mcmc.py
+++ b/discretesampling/base/algorithms/mcmc.py
@@ -1,5 +1,6 @@
 import math
 import copy
+from tqdm.auto import tqdm
 from discretesampling.base.random import RNG
 
 
@@ -11,13 +12,14 @@ class DiscreteVariableMCMC():
         self.initialProposal = initialProposal
         self.target = target
 
-    def sample(self, N, seed=0):
+    def sample(self, N, seed=0, verbose=True):
         rng = RNG(seed)
         initialSample = self.initialProposal.sample(rng)
         current = initialSample
 
         samples = []
-        for i in range(N):
+
+        for i in tqdm(range(N), disable=not verbose):
             forward_proposal = self.proposalType(current, rng)
             proposed = forward_proposal.sample()
 

--- a/discretesampling/base/algorithms/smc.py
+++ b/discretesampling/base/algorithms/smc.py
@@ -1,6 +1,7 @@
 import copy
 import numpy as np
 import math
+from tqdm.auto import tqdm
 from discretesampling.base.random import RNG
 from discretesampling.base.executor import Executor
 from discretesampling.base.algorithms.smc_components.normalisation import normalise
@@ -28,7 +29,7 @@ class DiscreteVariableSMC():
         self.initialProposal = initialProposal
         self.target = target
 
-    def sample(self, Tsmc, N, seed=0):
+    def sample(self, Tsmc, N, seed=0, verbose=True):
         loc_n = int(N/self.exec.P)
         rank = self.exec.rank
         mvrs_rng = RNG(seed)
@@ -38,7 +39,9 @@ class DiscreteVariableSMC():
         current_particles = initialParticles
         logWeights = np.array([self.target.eval(p) - self.initialProposal.eval(p, self.target) for p in initialParticles])
 
-        for t in range(Tsmc):
+        display_progress_bar = verbose and rank == 0
+
+        for t in tqdm(range(Tsmc), disable=not display_progress_bar):
             logWeights = normalise(logWeights, self.exec)
             neff = ess(logWeights, self.exec)
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,7 @@ scipy
 scikit-learn
 pandas
 mpi4py
+tqdm
 flake8
 pytest
 pytest-mpi


### PR DESCRIPTION
Add progress bars for SMC/MCMC iterations using tqdm.
Add "verbose" parameter to DiscreteVariableSMC and DiscreteVariableMCMC (default = True) which enables/disables showing the
progress bar.