### PR TITLE
refactor: proposals

### DIFF
--- a/discretesampling/base/algorithms/mcmc.py
+++ b/discretesampling/base/algorithms/mcmc.py
@@ -6,9 +6,12 @@ from discretesampling.base.random import RNG
 
 class DiscreteVariableMCMC():
 
-    def __init__(self, variableType, target, initialProposal):
+    def __init__(self, variableType, target, initialProposal, proposal=None):
         self.variableType = variableType
         self.proposalType = variableType.getProposalType()
+        self.proposal = proposal
+        if proposal is None:
+            self.proposal = self.proposalType()
         self.initialProposal = initialProposal
         self.target = target
 
@@ -23,13 +26,13 @@ class DiscreteVariableMCMC():
         progress_bar = tqdm(total=N, desc="MCMC sampling", disable=not display_progress_bar)
 
         for i in range(N):
-            forward_proposal = self.proposalType(current, rng)
-            proposed = forward_proposal.sample()
+            forward_proposal = self.proposal
+            proposed = forward_proposal.sample(current, rng=rng)
 
-            reverse_proposal = self.proposalType(proposed, rng)
+            reverse_proposal = self.proposal
 
-            forward_logprob = forward_proposal.eval(proposed)
-            reverse_logprob = reverse_proposal.eval(current)
+            forward_logprob = forward_proposal.eval(current, proposed)
+            reverse_logprob = reverse_proposal.eval(proposed, current)
 
             current_target_logprob = self.target.eval(current)
             proposed_target_logprob = self.target.eval(proposed)

--- a/discretesampling/base/kernel.py
+++ b/discretesampling/base/kernel.py
@@ -5,17 +5,16 @@ from scipy.special import logsumexp
 
 
 class DiscreteVariableOptimalLKernel:
-    def __init__(self, current_particles, previous_particles,
+    def __init__(self, current_particles, previous_particles, proposal=None,
                  parallel=False, num_cores=None):
         self.current_particles = current_particles
         self.previous_particles = previous_particles
         self.proposalType = type(self.current_particles[0]).getProposalType()
+        self.proposal = proposal
+        if proposal is None:
+            self.proposal = self.proposalType()
         self.parallel = parallel
         self.num_cores = num_cores
-
-        self.forward_proposals = [
-            self.proposalType(particle) for particle in self.previous_particles
-        ]
 
         # If parallel, calculate eta and proposal_possible in parallel
         # Then precalculate logprob
@@ -107,7 +106,8 @@ class DiscreteVariableOptimalLKernel:
             forward_probabilities = np.zeros(len(self.previous_particles))
             for j in range(len(self.previous_particles)):
                 if self.proposal_possible[p, j] == 1:
-                    forward_probabilities[j] = self.forward_proposals[j].eval(
+                    forward_probabilities[j] = self.proposal.eval(
+                        self.previous_particles[j],
                         self.current_particles[p]
                     )
 

--- a/discretesampling/base/types.py
+++ b/discretesampling/base/types.py
@@ -41,7 +41,7 @@ class DiscreteVariable:
 
 
 class DiscreteVariableProposal:
-    def __init__(self, values, probs, rng=RNG()):
+    def __init__(self, values, probs):
         # Check dims and probs are valid
         assert len(values) == len(probs), "Invalid PMF specified, x and p" +\
             " of different lengths"
@@ -54,7 +54,6 @@ class DiscreteVariableProposal:
         self.x = values
         self.pmf = probs
         self.cmf = np.cumsum(probs)
-        self.rng = rng
 
     @classmethod
     def norm(self, x):
@@ -67,11 +66,11 @@ class DiscreteVariableProposal:
     def heuristic(self, x, y):
         return True
 
-    def sample(self, target=None):
-        q = self.rng.random()  # random unif(0,1)
+    def sample(self, x, rng=RNG(), target=None):
+        q = rng.random()  # random unif(0,1)
         return self.x[np.argmax(self.cmf >= q)]
 
-    def eval(self, y, target=None):
+    def eval(self, x, y, target=None):
         try:
             i = self.x.index(y)
             logp = math.log(self.pmf[i])

--- a/discretesampling/base/types.py
+++ b/discretesampling/base/types.py
@@ -1,3 +1,5 @@
+from abc import ABC, abstractmethod
+from typing import Union
 import math
 from pickle import loads, dumps
 import numpy as np
@@ -5,17 +7,19 @@ from discretesampling.base.random import RNG
 from discretesampling.base.kernel import DiscreteVariableOptimalLKernel
 
 
-class DiscreteVariable:
+class DiscreteVariable(ABC):
     def __init__(self):
         pass
 
     @classmethod
+    @abstractmethod
     def getProposalType(self):
-        return DiscreteVariableProposal
+        pass
 
     @classmethod
+    @abstractmethod
     def getTargetType(self):
-        return DiscreteVariableTarget
+        pass
 
     @classmethod
     def getLKernelType(self):
@@ -40,86 +44,77 @@ class DiscreteVariable:
         return decoded
 
 
-class DiscreteVariableProposal:
-    def __init__(self, values, probs):
-        # Check dims and probs are valid
-        assert len(values) == len(probs), "Invalid PMF specified, x and p" +\
-            " of different lengths"
-        probs = np.array(probs)
-        tolerance = np.sqrt(np.finfo(np.float64).eps)
-        assert abs(1 - sum(probs)) < tolerance, "Invalid PMF specified," +\
-            " sum of probabilities !~= 1.0"
-        assert all(probs > 0), "Invalid PMF specified, all probabilities" +\
-            " must be > 0"
-        self.x = values
-        self.pmf = probs
-        self.cmf = np.cumsum(probs)
-
-    @classmethod
-    def norm(self, x):
-        return 1
-
-    @classmethod
-    # Should return true if proposal is possible between x and y
-    # (and possibly at other times)
-    # where x and y are norm values from the above function
-    def heuristic(self, x, y):
-        return True
-
-    def sample(self, x, rng=RNG(), target=None):
-        q = rng.random()  # random unif(0,1)
-        return self.x[np.argmax(self.cmf >= q)]
-
-    def eval(self, x, y, target=None):
-        try:
-            i = self.x.index(y)
-            logp = math.log(self.pmf[i])
-        except ValueError:
-            print("Warning: value " + str(y) + " not in pmf")
-            logp = -math.inf
-        return logp
-
-
-# Exact same as proposal above
-class DiscreteVariableInitialProposal():
-    def __init__(self, values, probs):
-        # Check dims and probs are valid
-        assert len(values) == len(probs), "Invalid PMF specified, x and p" +\
-            " of different lengths"
-        probs = np.array(probs)
-        tolerance = np.sqrt(np.finfo(np.float64).eps)
-        assert abs(1 - sum(probs)) < tolerance, "Invalid PMF specified," +\
-            " sum of probabilities !~= 1.0"
-        assert all(probs > 0), "Invalid PMF specified, all probabilities" +\
-            " must be > 0"
-        self.x = values
-        self.pmf = probs
-        self.cmf = np.cumsum(probs)
-
-    def sample(self, rng=RNG(), target=None):
-        q = rng.random()  # random unif(0,1)
-        return self.x[np.argmax(self.cmf >= q)]
-
-    def eval(self, y, target=None):
-        try:
-            i = self.x.index(y)
-            logp = math.log(self.pmf[i])
-        except ValueError:
-            print("Warning: value " + str(y) + " not in pmf")
-            logp = -math.inf
-        return logp
-
-
-class DiscreteVariableTarget:
+class DiscreteVariableProposal(ABC):
     def __init__(self):
         pass
 
-    def eval(self, x):
-        logprob = -math.inf
-        logPrior = self.evaluatePrior(x)
-        logprob += logPrior
-        return logprob
+    @abstractmethod
+    def norm(self, x):
+        pass
 
-    def evaluatePrior(self, x):
-        logprob = -math.inf
-        return logprob
+    # Should return true if proposal is possible between x and y
+    # (and possibly at other times)
+    # where x and y are norm values from the above function
+    @abstractmethod
+    def heuristic(self, x, y):
+        pass
+
+    @abstractmethod
+    def sample(
+        self,
+        x: DiscreteVariable,
+        rng: RNG = RNG(),
+        target: Union[None, 'DiscreteVariableTarget'] = None
+    ) -> 'DiscreteVariable':
+        pass
+
+    @abstractmethod
+    def eval(
+        self,
+        x: DiscreteVariable,
+        x_prime: DiscreteVariable,
+        target: Union[None, 'DiscreteVariableTarget'] = None
+    ) -> float:
+        pass
+
+
+# Exact same as proposal above
+class DiscreteVariableInitialProposal(ABC):
+    def __init__(self, values, probs):
+        # Check dims and probs are valid
+        assert len(values) == len(probs), "Invalid PMF specified, x and p" +\
+            " of different lengths"
+        probs = np.array(probs)
+        tolerance = np.sqrt(np.finfo(np.float64).eps)
+        assert abs(1 - sum(probs)) < tolerance, "Invalid PMF specified," +\
+            " sum of probabilities !~= 1.0"
+        assert all(probs > 0), "Invalid PMF specified, all probabilities" +\
+            " must be > 0"
+        self.x = values
+        self.pmf = probs
+        self.cmf = np.cumsum(probs)
+
+    def sample(self, rng: RNG = RNG(), target: Union[None, 'DiscreteVariableTarget'] = None) -> DiscreteVariable:
+        q = rng.random()  # random unif(0,1)
+        return self.x[np.argmax(self.cmf >= q)]
+
+    def eval(self, y: DiscreteVariable, target: Union[None, 'DiscreteVariableTarget'] = None) -> float:
+        try:
+            i = self.x.index(y)
+            logp = math.log(self.pmf[i])
+        except ValueError:
+            print("Warning: value " + str(y) + " not in pmf")
+            logp = -math.inf
+        return logp
+
+
+class DiscreteVariableTarget(ABC):
+    def __init__(self):
+        pass
+
+    @abstractmethod
+    def eval(self, x: DiscreteVariable) -> float:
+        pass
+
+    def evaluatePrior(self, x: DiscreteVariable) -> float:
+        pass

--- a/examples/mpi/decision_tree_example.py
+++ b/examples/mpi/decision_tree_example.py
@@ -17,13 +17,14 @@ X_train, X_test, y_train, y_test = train_test_split(X, y, test_size=0.30, random
 a = 15
 target = dt.TreeTarget(a)
 initialProposal = dt.TreeInitialProposal(X_train, y_train)
-
+proposal = dt.TreeProposal()
 N = 1 << 10
 T = 10
 seed = 0
 
 exec = Executor_MPI()
-dtSMC = DiscreteVariableSMC(dt.Tree, target, initialProposal, False, exec=exec)
+
+dtSMC = DiscreteVariableSMC(dt.Tree, target, initialProposal, proposal=proposal, use_optimal_L=False, exec=exec)
 try:
     MPI.COMM_WORLD.Barrier()
     start = MPI.Wtime()

--- a/examples/mpi/regression_tree_example.py
+++ b/examples/mpi/regression_tree_example.py
@@ -23,7 +23,7 @@ T = 10
 seed = 0
 
 exec = Executor_MPI()
-dtSMC = DiscreteVariableSMC(dt.Tree, target, initialProposal, False, exec=exec)
+dtSMC = DiscreteVariableSMC(dt.Tree, target, initialProposal, use_optimal_L=False, exec=exec)
 try:
     MPI.COMM_WORLD.Barrier()
     start = MPI.Wtime()

--- a/tests/test_additive_structure.py
+++ b/tests/test_additive_structure.py
@@ -58,8 +58,8 @@ def test_additive_structure_proposal_heuristic(ad_a, ad_b, expected):
      (AdditiveStructure([[1], [2], [3], [4], [5]]), AdditiveStructure([[1], [2], [3], [4, 5]]), np.log(0.1))]
 )
 def test_additive_structure_proposal_eval(ad_start, ad_end, expected):
-    prop = AdditiveStructureProposal(ad_start)
-    logprob = prop.eval(ad_end)
+    prop = AdditiveStructureProposal()
+    logprob = prop.eval(ad_start, ad_end)
     np.testing.assert_almost_equal(logprob, expected)
 
 
@@ -71,8 +71,8 @@ def test_additive_structure_proposal_eval(ad_start, ad_end, expected):
      (3, AdditiveStructure([[1], [2], [3], [4], [5]]), AdditiveStructure([[1], [2], [3, 5], [4]]))]
 )
 def test_additive_structure_proposal_sample(seed, ad_start, expected):
-    prop = AdditiveStructureProposal(ad_start, rng=RNG(seed))
-    sampled = prop.sample()
+    prop = AdditiveStructureProposal()
+    sampled = prop.sample(ad_start, rng=RNG(seed))
     assert sampled == expected
 
 

--- a/tests/test_decision_tree.py
+++ b/tests/test_decision_tree.py
@@ -187,7 +187,7 @@ def test_tree_swap(seed, tree, expected):
                   [2, 5, 6, 3, 15.2, 2], [6, 7, 8, 6, 0.66, 3]], [3, 4, 5, 7, 8]))]
 )
 def test_tree_proposal_sample(seed, tree, expected):
-    new_tree = TreeProposal(tree, rng=RNG(seed)).sample()
+    new_tree = TreeProposal().sample(tree, rng=RNG(seed))
     assert new_tree == expected
 
 
@@ -211,7 +211,7 @@ def test_tree_proposal_sample(seed, tree, expected):
       -10.519321629993403)]
 )
 def test_tree_proposal_eval(tree_a, tree_b, expected):
-    logprob = TreeProposal(tree_a).eval(tree_b)
+    logprob = TreeProposal().eval(tree_a, tree_b)
     np.testing.assert_almost_equal(logprob, expected)
 
 

--- a/tests/test_discrete_variable.py
+++ b/tests/test_discrete_variable.py
@@ -9,6 +9,12 @@ class ExampleParticleClass(DiscreteVariable):
     def __eq__(self, other):
         return self.x == other.x
 
+    def getProposalType(self):
+        return super().getProposalType()
+
+    def getTargetType(self):
+        return super().getTargetType()
+
 
 @pytest.mark.parametrize(
     "x",

--- a/tests/test_executor.py
+++ b/tests/test_executor.py
@@ -11,6 +11,12 @@ class ExampleParticleClass(DiscreteVariable):
     def __eq__(self, other):
         return self.x == other.x
 
+    def getProposalType(self):
+        return super().getProposalType()
+
+    def getTargetType(self):
+        return super().getTargetType()
+
 
 @pytest.mark.parametrize(
     "x,expected",

--- a/tests/test_executor_MPI.py
+++ b/tests/test_executor_MPI.py
@@ -11,6 +11,12 @@ class ExampleParticleClass(DiscreteVariable):
     def __eq__(self, other):
         return self.x == other.x
 
+    def getProposalType(self):
+        return super().getProposalType()
+
+    def getTargetType(self):
+        return super().getTargetType()
+
 
 def split_across_cores(N, P, rank):
     local_n = int(np.ceil(N/P))

--- a/tests/test_smc_components.py
+++ b/tests/test_smc_components.py
@@ -16,6 +16,12 @@ class ExampleParticleClass(DiscreteVariable):
     def __eq__(self, other):
         return self.x == other.x
 
+    def getProposalType(self):
+        return super().getProposalType()
+
+    def getTargetType(self):
+        return super().getTargetType()
+
 
 def split_across_cores(N, P, rank):
     local_n = int(np.ceil(N/P))

--- a/tests/test_spectrum.py
+++ b/tests/test_spectrum.py
@@ -56,8 +56,8 @@ def test_spectrum_proposal_heuristic(a, b, expected):
      (SpectrumDimension(2), 4, SpectrumDimension(3))]
 )
 def test_spectrum_proposal_sample(start_spectrum, seed, expected):
-    prop = SpectrumDimensionProposal(start_spectrum, rng=RNG(seed))
-    sampled = prop.sample()
+    prop = SpectrumDimensionProposal()
+    sampled = prop.sample(start_spectrum, rng=RNG(seed))
     assert sampled == expected
 
 
@@ -71,8 +71,8 @@ def test_spectrum_proposal_sample(start_spectrum, seed, expected):
      (SpectrumDimension(1), SpectrumDimension(0), -np.inf)]
 )
 def test_spectrum_proposal_eval(start_spectrum, end_spectrum, expected):
-    prop = SpectrumDimensionProposal(start_spectrum)
-    logprob = prop.eval(end_spectrum)
+    prop = SpectrumDimensionProposal()
+    logprob = prop.eval(start_spectrum, end_spectrum)
     assert logprob == expected
 
 


### PR DESCRIPTION
Change so that proposals represent a configuration of a proposal distribution, rather than a proposal conditional on the initial value.

An instance of DiscreteVariableProposal(some_config) is now a particular proposal distribution q(.|.), whereas before an instance of DiscreteVariableProposal(x) represented a proposal conditional on the starting value q(.|x). This will enable user-configuration of e.g. move probabilities (and potentially tuning of move probabilities by an as-yet-unspecified "proposal-generator"). This will also facilitate some refactoring I think needs to happen to enable reversible jump and HINTS to be integrated smoothly.

- Each of the types in `discretesampling/base/types` is now an abstract base class, which better reflects their intended purpose. Some methods are concrete (and can be overridden by subclasses where appropriate), others are abstract and must be implemented by subclasses.

- Constructors of DiscreteVariableProposal now do not take as input the starting value x. Instead they can (optionally) be configured to modify the behaviour of the proposal distribution, e.g. specifying move probabilities. The constructor might specify some sensible defaults that the user can override.

- .sample now takes starting value x as input and outputs a sample x':
```
x_prime = proposal.sample(x)
```
- .eval now takes starting value x and end value x' and outputs log probability of transition from x to x':
```
forward_log_prob = proposal.sample(x, x_prime)
```

- Edited tests and SMC/MCMC accordingly to match above

